### PR TITLE
1. use getopts to parse options like -j10, -j 10.

### DIFF
--- a/kernel-metadata-regen-calyx.sh
+++ b/kernel-metadata-regen-calyx.sh
@@ -42,4 +42,7 @@ for kernel in $kernels; do
 	) &
 done
 
+# https://stackoverflow.com/questions/14562423/is-there-a-way-to-ignore-header-lines-in-a-unix-sort
+awk 'NR<3{print $0;next}{print $0| "sort"}' ${KERNEL_MIRROR_MANIFEST}/calyx-metadata | sponge ${KERNEL_MIRROR_MANIFEST}/calyx-metadata
+
 wait

--- a/kernel-metadata-regen-lineage.sh
+++ b/kernel-metadata-regen-lineage.sh
@@ -70,4 +70,7 @@ for kernel in $kernels; do
 	) &
 done
 
+# https://stackoverflow.com/questions/14562423/is-there-a-way-to-ignore-header-lines-in-a-unix-sort
+awk 'NR<3{print $0;next}{print $0| "sort"}' ${KERNEL_MIRROR_MANIFEST}/lineage-metadata | sponge ${KERNEL_MIRROR_MANIFEST}/lineage-metadata
+
 wait

--- a/sync.sh
+++ b/sync.sh
@@ -5,8 +5,8 @@ MIRROR_ROOT="${SCRIPT_PATH}/../.."
 
 export REPO_TRACE=0
 
-# Default to repo sync -j64
-SYNC_JOBS=64
+# Default to repo sync -j`nproc`
+SYNC_JOBS=`nproc`
 
 while [ "${#}" -gt 0 ]; do
     case "${1}" in

--- a/sync.sh
+++ b/sync.sh
@@ -8,11 +8,11 @@ export REPO_TRACE=0
 # Default to repo sync -j`nproc`
 SYNC_JOBS=`nproc`
 
-while [ "${#}" -gt 0 ]; do
-    case "${1}" in
-        -j | --jobs )
-                SYNC_JOBS="${2}";
-                ;;
+while getopts 'j:' OPTION; do
+    case "$OPTION" in
+        j)
+            SYNC_JOBS=$OPTARG
+            ;;
     esac
     shift
 done


### PR DESCRIPTION
2. sort the metadata list, so that human have a broader view of kernel repos.